### PR TITLE
[Aleo ins] Update to latest ABNF on master.

### DIFF
--- a/aleo-instructions/Aleo.tmLanguage
+++ b/aleo-instructions/Aleo.tmLanguage
@@ -56,14 +56,14 @@
         <key>name</key>
         <string>keyword.control.aleo</string>
         <key>match</key>
-        <string>\b(function|program|as|by|interface|closure|into|import)\b</string>
+        <string>\b(function|program|as|closure|into|import|record|mapping|key|value|struct|input|output|to)\b</string>
       </dict>
       <key>finalize</key>
       <dict>
         <key>name</key>
         <string>finalize.aleo</string>
         <key>match</key>
-        <string>\b(finalize|mapping|increment|decrement)\b</string>
+        <string>\b(finalize|contains|get|get\.or_use|set|remove|rand\.chacha|position|branch\.eq|branch\.neq)\b</string>
       </dict>
       <key>qualifiers</key>
       <dict>
@@ -77,21 +77,21 @@
         <key>name</key>
         <string>visibility.aleo</string>
         <key>match</key>
-        <string>\b(constant|public|private|record)\b</string>
+        <string>\b(constant|public|private|aleo)\b</string>
       </dict>
       <key>instructions</key>
       <dict>
         <key>name</key>
         <string>instruction.aleo</string>
         <key>match</key>
-        <string>\b(abs\.w|abs|add\.w|add|and|assert\.eq|assert\.neq|call|cast|commit\.bhp256|commit\.bhp512|commit\.bhp768|commit\.bhp1024|commit\.ped64|commit\.ped128|div\.w|div|double|gt|gte|hash\.bhp256|hash\.bhp512|hash\.bhp768|hash\.bhp1024|hash\.ped64|hash\.ped128|hash\.psd2|hash\.psd4|hash\.psd8|inv|input|is\.eq|is\.neq|lt|lte|key|mod|mul\.w|mul|nand|neg|nor|not|or|output|pow\.w|pow|rem\.w|rem|shl\.w|shl|shr\.w|srh|sqrt|sub\.w|sub|square|ternary|value|xor)\b</string>
+        <string>\b(abs\.w|abs|add\.w|add|and|assert\.eq|assert\.neq|call|cast|commit\.bhp256|commit\.bhp512|commit\.bhp768|commit\.bhp1024|commit\.ped64|commit\.ped128|div\.w|div|double|gt|gte|hash\.bhp256|hash\.bhp512|hash\.bhp768|hash\.bhp1024|hash\.ped64|hash\.ped128|hash\.psd2|hash\.psd4|hash\.psd8|hash\.keccak256|hash\.keccak384|hash\.keccak512||hash\.sha3_256|hash\.sha3_384|hash\.sha3_512|hash_many\.psd2|hash_many\.psd4|hash_many\.psd8|inv|is\.eq|is\.neq|lt|lte|mod|mul\.w|mul|nand|neg|nor|not|or|pow\.w|pow|rem\.w|rem|shl\.w|shl|shr\.w|shr|sqrt|sub\.w|sub|square|ternary|xor|sign\.verify)\b</string>
       </dict>
       <key>numbers</key>
       <dict>
         <key>name</key>
         <string>constant.numeric.aleo</string>
         <key>match</key>
-        <string>-?\b\d+(\.\d+)?\b</string>
+        <string>-?\b\d+(\_\d+)?\b</string>
       </dict>
       <key>strings</key>
       <dict>

--- a/aleo-instructions/Aleo.tmLanguage
+++ b/aleo-instructions/Aleo.tmLanguage
@@ -77,7 +77,7 @@
         <key>name</key>
         <string>visibility.aleo</string>
         <key>match</key>
-        <string>\b(constant|public|private|aleo)\b</string>
+        <string>\b(constant|public|private)\b</string>
       </dict>
       <key>instructions</key>
       <dict>

--- a/aleo-instructions/Aleo.tmLanguage.json
+++ b/aleo-instructions/Aleo.tmLanguage.json
@@ -46,7 +46,7 @@
     },
     "visibility": {
       "name": "visibility.aleo",
-      "match": "\\b(constant|public|private|aleo)\\b"
+      "match": "\\b(constant|public|private)\\b"
     },
     "instructions": {
       "name": "instruction.aleo",

--- a/aleo-instructions/Aleo.tmLanguage.json
+++ b/aleo-instructions/Aleo.tmLanguage.json
@@ -34,11 +34,11 @@
   "repository": {
     "keywords": {
       "name": "keyword.control.aleo",
-      "match": "\\b(function|program|as|by|interface|closure|into|import)\\b"
+      "match": "\\b(function|program|as|closure|into|import|record|mapping|key|value|struct|input|output|to)\\b"
     },
     "finalize": {
       "name": "finalize.aleo",
-      "match": "\\b(finalize|mapping|increment|decrement)\\b"
+      "match": "\\b(finalize|contains|get|get\\.or_use|set|remove|rand\\.chacha|position|branch\\.eq|branch\\.neq)\\b"
     },
     "qualifiers": {
       "name": "qualifiers.aleo",
@@ -46,15 +46,15 @@
     },
     "visibility": {
       "name": "visibility.aleo",
-      "match": "\\b(constant|public|private|record|aleo)\\b"
+      "match": "\\b(constant|public|private|aleo)\\b"
     },
     "instructions": {
       "name": "instruction.aleo",
-      "match": "\\b(abs\\.w|abs|add\\.w|add|and|assert\\.eq|assert\\.neq|call|cast|commit\\.bhp256|commit\\.bhp512|commit\\.bhp768|commit\\.bhp1024|commit\\.ped64|commit\\.ped128|div\\.w|div|double|gt|gte|hash\\.bhp256|hash\\.bhp512|hash\\.bhp768|hash\\.bhp1024|hash\\.ped64|hash\\.ped128|hash\\.psd2|hash\\.psd4|hash\\.psd8|inv|input|is\\.eq|is\\.neq|lt|lte|key|mod|mul\\.w|mul|nand|neg|nor|not|or|output|pow\\.w|pow|rem\\.w|rem|shl\\.w|shl|shr\\.w|srh|sqrt|sub\\.w|sub|square|ternary|value|xor)\\b"
+      "match": "\\b(abs\\.w|abs|add\\.w|add|and|assert\\.eq|assert\\.neq|call|cast|commit\\.bhp256|commit\\.bhp512|commit\\.bhp768|commit\\.bhp1024|commit\\.ped64|commit\\.ped128|div\\.w|div|double|gt|gte|hash\\.bhp256|hash\\.bhp512|hash\\.bhp768|hash\\.bhp1024|hash\\.ped64|hash\\.ped128|hash\\.psd2|hash\\.psd4|hash\\.psd8|hash\\.keccak256|hash\\.keccak384|hash\\.keccak512||hash\\.sha3_256|hash\\.sha3_384|hash\\.sha3_512|hash_many\\.psd2|hash_many\\.psd4|hash_many\\.psd8|inv|is\\.eq|is\\.neq|lt|lte|mod|mul\\.w|mul|nand|neg|nor|not|or|pow\\.w|pow|rem\\.w|rem|shl\\.w|shl|shr\\.w|shr|sqrt|sub\\.w|sub|square|ternary|xor|sign\\.verify)\\b"
     },
     "numbers": {
       "name": "constant.numeric.aleo",
-      "match": "-?[0-9.]+"
+      "match": "-?[0-9_]+"
     },
     "strings": {
       "name": "string.quoted.double.aleo",


### PR DESCRIPTION
- Remove keywords that are no longer there.
- Add more keywords. Rationale: keywords are the things used to introduce/declare something.
- Reclassify `record` from visibilities to keywords, because it's of the same kind as `function`, `struct`, etc.
- Reclassify a few things from instructions to keywords.
- Replace `.` with `_` in numbers, because we allow underscores but not dots in numeric literals.
- Instructions are under instructions, and non-instruction commands are under finalize.
- Remove `aleo` from visibilities.